### PR TITLE
Change Filesystem Format from VFAT to EXT4

### DIFF
--- a/NVME Slot/README.md
+++ b/NVME Slot/README.md
@@ -36,7 +36,7 @@ Execute n to add the partition, and then just type enter enter enter until a new
 
 ### Format
 ```sh
-sudo mkfs.vfat -F 32 /dev/nvme0n1p1
+sudo mkfs.ext4 /dev/nvme0n1p1
 ```
 Wait for a few moments, when done has appeared, it means that the formatting has been carried out.
 ![1a0374a7-da44-4201-9268-f5ef6763b0c1](https://github.com/user-attachments/assets/59d68cfb-bc9b-4627-8ab2-7d934cb8fa68)
@@ -106,4 +106,5 @@ Modify BOOT_ORDER=0xf41 as BOOT_ORDER=0xf416
 
 
 Remove the tf card and reboot the HackberryPi then the system should be rebooted from the SSD, it's about 10 seconds faster than booting from tf card(RaspberryPi OS)
+
 


### PR DESCRIPTION
This pull request changes the filesystem formatting command to the correct one, which is shown in the screenshot. The line is updated from:
    sudo mkfs.vfat -F 32 /dev/nvme0n1p1
to
    sudo mkfs.ext4 /dev/nvme0n1p1
The new command is the appropriate format for the intended use.
